### PR TITLE
Optionally show the folder path when search for target folder

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -20,6 +20,12 @@
   "markAsRead.title": {
     "message": ""
   },
+  "showFolderPath": {
+    "message": "Show full path of each folder in search box"
+  },
+  "showFolderPath.title": {
+    "message": ""
+  },
   "maxRecentFolders": {
     "message": "Number of Recent Folders"
   },

--- a/options/options.html
+++ b/options/options.html
@@ -23,5 +23,9 @@
       <button id="useLegacyShortcuts" data-l10n-id="useLegacyShortcuts"></button>
       <div id="useLegacyShortcutsDone"></div>
     </div>
+    <div class="browser-style preference">
+      <input type="checkbox" id="showFolderPath">
+      <label for="showFolderPath" data-l10n-id="showFolderPath"></label>
+    </div>
   </body>
 </html>

--- a/options/options.js
+++ b/options/options.js
@@ -6,6 +6,7 @@
 const DEFAULT_PREFERENCES = {
   markAsRead: true,
   maxRecentFolders: 15,
+  showFolderPath: false
 };
 
 async function restore_options() {

--- a/popup/folderlist.js
+++ b/popup/folderlist.js
@@ -426,6 +426,15 @@ class TBFolderList extends HTMLElement {
     this.repopulate();
   }
 
+  get showFolderPath() {
+    return this._showFolderPath;
+  }
+
+  set showFolderPath(val) {
+    this._showFolderPath = val;
+    this.repopulate();
+  }
+
   focusSearch() {
     this.search.focus();
     let selected = this.shadowRoot.querySelector(".folder-list-body .folder-item.selected");
@@ -435,8 +444,6 @@ class TBFolderList extends HTMLElement {
   }
 
   async repopulate() {
-    let vars = await browser.storage.local.get({ showFolderPath: true });
-    this._showFolderPath = vars.showFolderPath;
     this._repopulate();
   }
 

--- a/popup/folderlist.js
+++ b/popup/folderlist.js
@@ -443,11 +443,7 @@ class TBFolderList extends HTMLElement {
     }
   }
 
-  async repopulate() {
-    this._repopulate();
-  }
-
-  _repopulate() {
+  repopulate() {
     let lowerSearchTerm = this.searchValue.toLowerCase();
     this._clearFolders();
 

--- a/popup/folderlist.js
+++ b/popup/folderlist.js
@@ -112,6 +112,7 @@ class TBFolderList extends HTMLElement {
         font-family: "Lucida Grande", caption;
         font-size: .847em;
         justify-content: flex-end;
+        margin-inline-start: 5px;
       }
 
       .folder-item > .icon {
@@ -230,6 +231,7 @@ class TBFolderList extends HTMLElement {
 
     this._accounts = {};
     this._defaultFolders = null;
+    this._showFolderPath = false;
   }
 
   connectedCallback() {
@@ -365,6 +367,9 @@ class TBFolderList extends HTMLElement {
     item.querySelector(".icon").classList.add("folder-type-" + (folder.type || "folder"));
     item.querySelector(".icon").style.marginInlineStart = (depth * 10) + "px";
     item.querySelector(".text").textContent = folder.name;
+    if (this._showFolderPath) {
+      item.querySelector(".text-shortcut").textContent = folder.path.split('/').slice(0, -1).join('/');
+    }
 
     item.querySelector(".folder-item").folder = folder;
     item.querySelector(".folder-item").setAttribute("title", folder.path);
@@ -429,7 +434,13 @@ class TBFolderList extends HTMLElement {
     }
   }
 
-  repopulate() {
+  async repopulate() {
+    let vars = await browser.storage.local.get({ showFolderPath: true });
+    this._showFolderPath = vars.showFolderPath;
+    this._repopulate();
+  }
+
+  _repopulate() {
     let lowerSearchTerm = this.searchValue.toLowerCase();
     this._clearFolders();
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -24,7 +24,7 @@ async function load() {
   let accountNodes = accounts.map(account => new AccountNode(account));
   let folders = accountNodes.reduce((acc, node) => acc.concat([...node]), []);
 
-  let { maxRecentFolders } = await browser.storage.local.get({ maxRecentFolders: 15 });
+  let { maxRecentFolders, showFolderPath } = await browser.storage.local.get({ maxRecentFolders: 15, showFolderPath: true });
   let recent = await browser.quickmove.query({ recent: true, limit: maxRecentFolders, canFileMessages: true });
 
   let folderList = document.getElementById("folderList");
@@ -32,6 +32,7 @@ async function load() {
   folderList.accountNodes = accountNodes;
   folderList.allFolders = folders;
   folderList.defaultFolders = recent;
+  folderList.showFolderPath = showFolderPath;
 
   folderList.addEventListener("folder-selected", async (event) => {
     let operation = document.querySelector("input[name='action']:checked").value;


### PR DESCRIPTION
When you have several times the same name for a folder in several places of your hierarchy, it might be useful to display the context.

An option (set to false) by default enables the display of the containing folder:
![image](https://user-images.githubusercontent.com/981546/70860783-62801180-1f26-11ea-938e-b123370179b9.png)

When the option is checked, context folder is shown
![image](https://user-images.githubusercontent.com/981546/70860803-99562780-1f26-11ea-9027-8e40493a1fc3.png)
