### PR TITLE
Feature/exclude archives

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -19,5 +19,11 @@
   },
   "noResults": {
     "message": "<no results>"
+  },
+  "excludeArchives": {
+    "message": "Exclude Archives folder from search results"
+  },
+  "excludeArchives.title": {
+    "message": ""
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1,0 +1,29 @@
+{
+  "extensionName": {
+    "message": "Déplacement rapide"
+  },
+  "extensionDescription": {
+    "message": "Déplacez rapidement les messages dans d'autres dossiers au clavier"
+  },
+  "markAsRead": {
+    "message": "Marquer les messages comme lus lors du déplacement"
+  },
+  "markAsRead.title": {
+    "message": ""
+  },
+  "maxRecentFolders": {
+    "message": "Nombre de dossiers récents"
+  },
+  "maxRecentFolders.title": {
+    "message": "Modifie le nombre de dossiers récents affichés lorsque aucun texte de recherche n'est saisi."
+  },
+  "noResults": {
+    "message": "<pas de résultats>"
+  },
+  "excludeArchives": {
+    "message": "Exclure le dossier des Archives des résultats de recherche"
+  },
+  "excludeArchives.title": {
+    "message": ""
+  }
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -19,5 +19,9 @@
       <label for="maxRecentFolders" data-l10n-id="maxRecentFolders"></label>
       <input type="number" min="0" id="maxRecentFolders">
     </div>
+    <div class="browser-style">
+      <input type="checkbox" id="excludeArchives">
+      <label for="excludeArchives" data-l10n-id="excludeArchives"></label>
+    </div>
   </body>
 </html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -7,6 +7,7 @@
   let prefs = await browser.storage.local.get({
     markAsRead: true,
     maxRecentFolders: 15,
+    excludeArchives: false
   });
 
   for (let [name, value] of Object.entries(prefs)) {
@@ -37,6 +38,7 @@
     browser.storage.local.set({
       maxRecentFolders: parseInt(document.getElementById("maxRecentFolders").value, 10),
       markAsRead: document.getElementById("markAsRead").checked,
+      excludeArchives: document.getElementById("excludeArchives").checked
     });
   });
 })();


### PR DESCRIPTION
Hi, 
I have asked in issue [issue 4](https://github.com/kewisch/quickmove-extension/issues/4) an option to exclude Archives folder.

So I have some time this week-end and I would try to implement by myself.
So it is done and functional.
I'm not sure if isSpecialFolder method is the optimal one.

I also suggest french localization for your extension.

Thank you for your time to review my contribution.

See you.

PaysPlat
