### PR TITLE
Add options to improve the usability when working with many mailboxes and huge directory structures

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -19,5 +19,29 @@
   },
   "noResults": {
     "message": "<Keine Ergebnisse>"
+  },
+  "excludeArchives": {
+    "message": "Schliesse die Archivordner aus den Suchresultaten aus"
+  },
+  "excludeArchives.title": {
+    "message": ""
+  },
+  "alwaysShowFullPath": {
+    "message": "Zeige immer den gesamten Pfad zum Zielordner"
+  },
+  "alwaysShowFullPath.title": {
+    "message": ""
+  },
+  "alwaysShowMailbox": {
+    "message": "Zeige die Mailbox zu der der Zielordner gehört immer an"
+  },
+  "alwaysShowMailbox.title": {
+    "message": ""
+  },
+  "doNotCrop": {
+    "message": "Schneide die Ordnernamen nie ab"
+  },
+  "doNotCrop.title": {
+    "message": ""
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -25,5 +25,23 @@
   },
   "excludeArchives.title": {
     "message": ""
+  },
+  "alwaysShowFullPath": {
+    "message": "Always show the full path of destination folders"
+  },
+  "alwaysShowFullPath.title": {
+    "message": ""
+  },
+  "alwaysShowMailbox": {
+    "message": "Always show the folder's mailbox"
+  },
+  "alwaysShowMailbox.title": {
+    "message": ""
+  },
+  "doNotCrop": {
+    "message": "Do not crop folder names"
+  },
+  "doNotCrop.title": {
+    "message": ""
   }
 }

--- a/src/content/quickmove.js
+++ b/src/content/quickmove.js
@@ -178,10 +178,13 @@ var quickmove = (function() {
      * @param popup       The popup to add to
      * @param targetValue The searched text
      */
-    addFolders: function(folders, popup, targetValue) {
+    addFolders: async function(folders, popup, targetValue) {
       let dupeMap = {};
       let serverMap = {};
       let fullPathMap = {};
+      let alwaysShowFullPath = await Quickmove.getPref("alwaysShowFullPath", false);
+      let alwaysShowMailbox = await Quickmove.getPref("alwaysShowMailbox", false);
+      let doNotCrop = await Quickmove.getPref("doNotCrop", false);
 
       // First create a map of pretty names to find possible duplicates.
       for (let folder of folders) {
@@ -210,18 +213,22 @@ var quickmove = (function() {
         dupeMap[lowerName]++;
       }
 
+
       // Now add each folder, appending the server name if the folder name
       // itself would appear more than once.
       for (let folder of folders) {
         let node = document.createXULElement("menuitem");
+        if (doNotCrop) {
+          node.setAttribute("crop", "none");
+        }
         let label = folder.prettyName;
         let lowerLabel = label.toLowerCase();
 
-        if (lowerLabel in fullPathMap) {
+        if (lowerLabel in fullPathMap || alwaysShowFullPath) {
           label = Quickmove.getFullName(folder);
         }
 
-        if (lowerLabel in dupeMap && dupeMap[lowerLabel] > 1) {
+        if ((lowerLabel in dupeMap && dupeMap[lowerLabel] > 1) || alwaysShowMailbox) {
           label += " - " + folder.server.prettyName;
         }
         node.setAttribute("label", label);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -23,5 +23,17 @@
       <input type="checkbox" id="excludeArchives">
       <label for="excludeArchives" data-l10n-id="excludeArchives"></label>
     </div>
+    <div class="browser-style">
+      <input type="checkbox" id="alwaysShowFullPath">
+      <label for="alwaysShowFullPath" data-l10n-id="alwaysShowFullPath"></label>
+    </div>
+    <div class="browser-style">
+      <input type="checkbox" id="alwaysShowMailbox">
+      <label for="alwaysShowMailbox" data-l10n-id="alwaysShowMailbox"></label>
+    </div>
+    <div class="browser-style">
+      <input type="checkbox" id="doNotCrop">
+      <label for="doNotCrop" data-l10n-id="doNotCrop"></label>
+    </div>
   </body>
 </html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -8,6 +8,9 @@
     markAsRead: true,
     maxRecentFolders: 15,
     excludeArchives: false,
+    alwaysShowFullPath: false,
+    alwaysShowMailbox: false,
+    doNotCrop: false,
   });
 
   for (let [name, value] of Object.entries(prefs)) {
@@ -39,6 +42,9 @@
       maxRecentFolders: parseInt(document.getElementById("maxRecentFolders").value, 10),
       markAsRead: document.getElementById("markAsRead").checked,
       excludeArchives: document.getElementById("excludeArchives").checked,
+      alwaysShowFullPath: document.getElementById("alwaysShowFullPath").checked,
+      alwaysShowMailbox: document.getElementById("alwaysShowMailbox").checked,
+      doNotCrop: document.getElementById("doNotCrop").checked,
     });
   });
 })();


### PR DESCRIPTION
Introduce three new options which are supposed to improve the usability when working with many mailboxes and huge directory structures:

* `alwaysShowFullPath`: Show the full path to the folder even if there is no other folder of the same name.
* `alwaysShowMailbox`: Show the mailbox the folder belongs to, even if there is no folder of the same name in any other mailbox.
* `doNotCrop`: Do not crop the folder names, even if they are very long.

This pull request also contains the German translations for both the new options as well as a previously untranslated option.