### PR TITLE
First stab at reverse hierarchical display (bug 106)

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -93,9 +93,9 @@
     "message": "Sie können nun ⇧M ⇧Y und ⇧G verwenden. Ändere die Tastenkürzel in der Erweiterungsverwaltung für Tastenkürzel."
   },
   "reverseHierarchyCompact": {
-    "message": "Reverse hierarchy display (compact only)"
+    "message": "Hierarchieanzeige umkehren (nur kompakt)"
   },
   "reverseHierarchyCompact.title": {
-    "message": "Compact mode only. Show the folder name first, in a reverse hierarchy, with the account name at the end. Don't show a separate line for the account. The list is sorted by the folder name (leaf node)."
+    "message": "Nur Kompaktmodus. Zeigen Sie zuerst den Ordnernamen in umgekehrter Hierarchie und am Ende den Kontonamen an. Für das Konto keine separate Zeile anzeigen. Die Liste ist nach dem Ordnernamen (Blattknoten) sortiert."
   }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -91,5 +91,11 @@
   },
   "useLegacyShortcutsDone": {
     "message": "Sie können nun ⇧M ⇧Y und ⇧G verwenden. Ändere die Tastenkürzel in der Erweiterungsverwaltung für Tastenkürzel."
+  },
+  "reverseHierarchyCompact": {
+    "message": "Reverse hierarchy display (compact only)"
+  },
+  "reverseHierarchyCompact.title": {
+    "message": "Compact mode only. Show the folder name first, in a reverse hierarchy, with the account name at the end. Don't show a separate line for the account. The list is sorted by the folder name (leaf node)."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -91,5 +91,11 @@
   },
   "useLegacyShortcutsDone": {
     "message": "You can now use ⇧M ⇧Y and ⇧G. Change the keys in the extension shortcuts."
+  },
+  "reverseHierarchyCompact": {
+    "message": "Reverse hierarchy display (compact only)"
+  },
+  "reverseHierarchyCompact.title": {
+    "message": "Compact mode only. Show the folder name first, in a reverse hierarchy, with the account name at the end. Don't show a separate line for the account. The list is sorted by the folder name (leaf node)."
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -90,9 +90,9 @@
     "message": "Vous pouvez à présent utiliser ⇧M ⇧Y et ⇧G. Utilisez l'extention shortcut pour les modifier."
   },
   "reverseHierarchyCompact": {
-    "message": "Reverse hierarchy display (compact only)"
+    "message": "Affichage de la hiérarchie inversée (compact uniquement)"
   },
   "reverseHierarchyCompact.title": {
-    "message": "Compact mode only. Show the folder name first, in a reverse hierarchy, with the account name at the end. Don't show a separate line for the account. The list is sorted by the folder name (leaf node)."
+    "message": "Mode compact uniquement. Affichez d'abord le nom du dossier, dans une hiérarchie inversée, avec le nom du compte à la fin. N'affichez pas de ligne distincte pour le compte. La liste est triée par nom de dossier (nœud feuille)."
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -88,5 +88,11 @@
   },
   "useLegacyShortcutsDone": {
     "message": "Vous pouvez à présent utiliser ⇧M ⇧Y et ⇧G. Utilisez l'extention shortcut pour les modifier."
+  },
+  "reverseHierarchyCompact": {
+    "message": "Reverse hierarchy display (compact only)"
+  },
+  "reverseHierarchyCompact.title": {
+    "message": "Compact mode only. Show the folder name first, in a reverse hierarchy, with the account name at the end. Don't show a separate line for the account. The list is sorted by the folder name (leaf node)."
   }
 }

--- a/src/common/foldernode.js
+++ b/src/common/foldernode.js
@@ -141,16 +141,54 @@ export class FolderNode extends BaseNode {
     return node;
   }
 
-  get fullNameParts() {
+  getFullNameParts(includeAccountNode) {
     let parts = [];
     let node = this; // eslint-disable-line consistent-this
-    while (node && !(node instanceof AccountNode)) {
-      parts.unshift(node.item.name);
+    while (node) {
+      let isAcctNode = node instanceof AccountNode;
+      if (includeAccountNode || !isAcctNode) {
+        parts.unshift(node.item.name);
+      }
+      if (isAcctNode) {
+        break;
+      }
       node = node.parent;
     }
 
     return parts;
   }
+  
+  get fullPathReversed() {
+    let fullFolderPathComponents = this.getFullNameParts(true).filter((val) => {
+      // Filter out [Gmail] and empty path components.
+      return val !== "" && !val.includes("[");
+    });
+    
+    if (fullFolderPathComponents.length === 0) { 
+      return '';
+    }
+    
+    let display = '';
+    for (var i = fullFolderPathComponents.length - 1; i >= 1; i--) {
+      if (display !== '') {
+        display += ' ← ';
+      }
+      display += fullFolderPathComponents[i];
+    }
+    
+    if (display !== '') {
+      display += ' ← ';
+    }
+    
+    display += '<b>'  + fullFolderPathComponents[0] + '</b>';
+    
+    return display;
+  }
+
+  get fullNameParts() {
+    return this.getFullNameParts(false);
+  }
+  
 }
 
 export class AccountNode extends FolderNode {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -5,7 +5,8 @@ export const DEFAULT_PREFERENCES = {
   showFolderPath: false,
   useLegacyShortcuts: false,
   skipArchive: true,
-  defaultFolderSetting: "recent"
+  defaultFolderSetting: "recent",
+  reverseHierarchyCompact: false
 };
 
 export async function getValidatedDefaultFolders(accountNodes) {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -37,6 +37,10 @@
       <label for="useLegacyShortcuts" data-l10n-id="useLegacyShortcuts"></label>
     </div>
     <div class="preference">
+      <input type="checkbox" id="reverseHierarchyCompact">
+      <label for="reverseHierarchyCompact" data-l10n-id="reverseHierarchyCompact"></label>
+    </div>
+    <div class="preference">
       <span></span>
       <div>
         <button id="onboarding">Show instructions</button>

--- a/src/popup/baseItemList.js
+++ b/src/popup/baseItemList.js
@@ -479,9 +479,13 @@ export default class BaseItemList extends HTMLElement {
   repopulate() {
     let lowerSearchTerm = this.searchValue.toLowerCase();
     this.#clearItems();
+    let addMode;
+    let itemsToAdd;
 
     if (lowerSearchTerm) {
       let searchWords = lowerSearchTerm.split(/\s+/);
+      addMode = BaseItemList.MODE_SEARCH;
+      itemsToAdd = [];
 
       for (let item of this.allItems) {
         let itemText = this.getItemText(item).toLowerCase();
@@ -494,18 +498,26 @@ export default class BaseItemList extends HTMLElement {
         }
 
         if (!mismatch) {
-          this._addItem(item, BaseItemList.MODE_SEARCH);
+          itemsToAdd.push(item);
         }
       }
     } else if (this.defaultItems) {
-      for (let item of this.defaultItems) {
-        this._addItem(item, BaseItemList.MODE_DEFAULT);
-      }
+      addMode = BaseItemList.MODE_DEFAULT;
+      itemsToAdd = this.defaultItems;
     } else {
-      for (let item of this.allItems) {
-        this._addItem(item, BaseItemList.MODE_ALL);
-      }
+      addMode = BaseItemList.MODE_ALL;
+      itemsToAdd = this.allItems;
     }
+    
+    itemsToAdd = this.sortItems(itemsToAdd);
+    
+    for (let item of itemsToAdd) {
+      this._addItem(item, addMode);
+    }
+  }
+  
+  sortItems(items) {
+    return items;
   }
 }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -31,8 +31,8 @@ function switchList(action) {
 }
 
 async function load() {
-  let { maxRecentFolders, showFolderPath, skipArchive, layout, defaultFolderSetting } = await browser.storage.local.get({ maxRecentFolders: 15, showFolderPath: true, layout: "auto", skipArchive: true, defaultFolderSetting: "recent" });
-
+  let { maxRecentFolders, showFolderPath, skipArchive, layout, defaultFolderSetting, reverseHierarchyCompact } = await browser.storage.local.get({ maxRecentFolders: 15, showFolderPath: true, layout: "auto", skipArchive: true, defaultFolderSetting: "recent", reverseHierarchyCompact: false });
+  
   if (layout == "wide" || (layout == "auto" && window.outerWidth > 1400)) {
     document.documentElement.removeAttribute("compact");
     document.getElementById("folder-list").removeAttribute("compact");
@@ -97,7 +97,7 @@ async function load() {
 
   let folderList = document.getElementById("folder-list");
   folderList.accounts = accounts;
-  folderList.initItems(folders, defaultFolders, showFolderPath);
+  folderList.initItems(folders, defaultFolders, showFolderPath, reverseHierarchyCompact);
   folderList.ignoreFocus = true;
   folderList.addEventListener("item-selected", async (event) => {
     let operation = document.querySelector("input[name='action']:checked").value;


### PR DESCRIPTION
#106 

Here is my first stab at this. Notes:

1. I tried to use <span> with css for the bold account name, but it acted like it could not find the CSS definition in popus.css. I couldn't figure out how to use Inspector in the debug window to work on this. 
2. I reworked BaseItemList.repopulate() to call a sortItems() method which is overridden in TBFolderList and sorts if the corresponding preference is checked. 
3. I'm sorting the folder names on the display string, case insensitive. It might be better to sort a folder node at a time, probably won't matter in the long run. 
4. DE and FR translations are straight from Google Translate. 