### PR TITLE
fix: folder iterator for non-native thunderbird accounts

### DIFF
--- a/src/common/foldernode.js
+++ b/src/common/foldernode.js
@@ -55,6 +55,10 @@ export class FolderNode extends BaseNode {
     let folderNodes = {};
 
     for (let folder of folders) {
+      if !accountMap[folder.accountId] {
+        continue;
+      }
+
       let folderNode = accountMap[folder.accountId].lookup(folder.path);
       if (folderNode) {
         if (!(folder.accountId in folderNodes)) {


### PR DESCRIPTION
I'm using [Owl for exchange](https://addons.thunderbird.net/en-us/thunderbird/addon/owl-for-exchange/), which is an amazing extension to deal with microsoft outlook365/exchange madness. The problem is, it registers some kind of "special" account in the TB, which is not present in `accountMap`. Yet folders are, which creates an issue, when iterator tries to find the "parent" account for the folder.

![2024-08-03-115130_1864x128_scrot](https://github.com/user-attachments/assets/cb3af7ec-beb9-4d83-94d8-e23d4c72fca7)

I think the easiest workaround will be, just ignore it and proceed further, which is what I'm trying to do in this PR. But I'm not familar with JS that much, so if there is a better solution, I'm happy to implement it :)