### PR TITLE
Partial match on the full folder path when searching

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -109,5 +109,8 @@
     },
     "excludedFoldersSearchPlaceholder": {
         "message": "Search for a folder to exclude"
+    },
+    "partialMatchFullPath": {
+        "message": "Search for keywords within the entire folder path"
     }
 }

--- a/src/common/foldernode.js
+++ b/src/common/foldernode.js
@@ -78,6 +78,7 @@ class BaseNode {
 
 export class FolderNode extends BaseNode {
   _childClass = FolderNode;
+  #fullSearchString = null;
 
   static folderKey(accountId, path) {
     return `${accountId}://${path}`;
@@ -112,6 +113,13 @@ export class FolderNode extends BaseNode {
       return "tag";
     }
     return this.item.specialUse?.[0];
+  }
+
+  get fullSearchString() {
+    if (!this.#fullSearchString) {
+      this.#fullSearchString = this.fullNameParts.join("/");
+    }
+    return this.#fullSearchString;
   }
 }
 

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -7,7 +7,8 @@ export const DEFAULT_PREFERENCES = {
   skipArchive: true,
   defaultFolderSetting: "recent",
   migratedShiftArrow: false,
-  recentStrategy: "accessed"
+  recentStrategy: "accessed",
+  partialMatchFullPath: false,
 };
 
 export async function getValidatedFolders(rootNode, prefName) {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -32,6 +32,10 @@
       <input type="checkbox" id="skipArchive">
       <label for="skipArchive" data-l10n-id="skipArchive"></label>
     </div>
+    <div class="preference">
+      <input type="checkbox" id="partialMatchFullPath">
+      <label for="partialMatchFullPath" data-l10n-id="partialMatchFullPath"></label>
+    </div>
     <div class="preference" data-l10n-attr-title="useLegacyShortcutsTitle">
       <input type="checkbox" id="useLegacyShortcuts">
       <label for="useLegacyShortcuts" data-l10n-id="useLegacyShortcuts"></label>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -120,6 +120,8 @@ async function setupFolderChooser({ rootNode, folderPickerId, folderListId, pref
   let folderList = document.getElementById(folderListId);
   folderList.initItems(folders, null, true);
 
+  let { partialMatchFullPath } = await browser.storage.local.get({ partialMatchFullPath: DEFAULT_PREFERENCES.partialMatchFullPath });
+
   folderPicker.addEventListener("item-selected", (event) => {
     let newNode = rootNode.findFolder(event.detail.folder);
 
@@ -127,6 +129,7 @@ async function setupFolderChooser({ rootNode, folderPickerId, folderListId, pref
     let allItems = [...folderSet];
 
     folderList.allItems = allItems;
+    folderList.partialMatchFullPath = partialMatchFullPath;
     folderList.repopulate();
     folderPicker.searchValue = "";
 
@@ -141,6 +144,7 @@ async function setupFolderChooser({ rootNode, folderPickerId, folderListId, pref
     let allItems = [...folderSet];
 
     folderList.allItems = allItems;
+    folderList.partialMatchFullPath = partialMatchFullPath;
     folderList.repopulate();
 
     let storageData = allItems.map(item => ({ accountId: item.accountId, path: item.path }));

--- a/src/popup/folderList.js
+++ b/src/popup/folderList.js
@@ -141,11 +141,12 @@ class TBFolderList extends BaseItemList {
     return body.lastElementChild;
   }
 
-  initItems(allItems, defaultItems, showFolderPath=false, excludeSet=null) {
+  initItems(allItems, defaultItems, showFolderPath=false, excludeSet=null, partialMatchFullPath=false) {
     this._allItems = allItems;
     this._defaultItems = defaultItems;
     this.#showFolderPath = showFolderPath;
     this.#excludeSet = excludeSet || new Set();
+    this.partialMatchFullPath = partialMatchFullPath;
     this.repopulate();
   }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -37,7 +37,7 @@ async function load() {
 
   let {
     maxRecentFolders, showFolderPath, skipArchive, layout, defaultFolderSetting, migratedShiftArrow,
-    recentStrategy
+    recentStrategy, partialMatchFullPath
   } = await browser.storage.local.get(DEFAULT_PREFERENCES);
 
   if (layout == "wide" || (layout == "auto" && window.outerWidth > 1400)) {
@@ -138,7 +138,7 @@ async function load() {
   }
 
   let folderList = document.getElementById("folder-list");
-  folderList.initItems(rootNode.folderNodes, defaultFolders, showFolderPath, excludeSet);
+  folderList.initItems(rootNode.folderNodes, defaultFolders, showFolderPath, excludeSet, partialMatchFullPath);
   folderList.ignoreFocus = true;
   folderList.addEventListener("item-selected", async (event) => {
     let { folder, altMode } = event.detail;


### PR DESCRIPTION
I've implemented the partial match on the full folder path when searching in the popup as requested in #169.

I've added the `partialMatchFullPath` option in the option page, with [default](https://github.com/micz/quickmove-extension/blob/issue_169/src/common/util.js#L11) to `false`.

Then I've added the `partialMatchFullPath` public property to the `BaseItemList` class ([source](https://github.com/micz/quickmove-extension/blob/issue_169/src/popup/baseItemList.js#L20)).
That property is used in the `repopulate` method [here](https://github.com/micz/quickmove-extension/blob/issue_169/src/popup/baseItemList.js#L518).

The `partialMatchFullPath` property is set [here](https://github.com/micz/quickmove-extension/blob/issue_169/src/popup/folderList.js#L149) and [here](https://github.com/micz/quickmove-extension/blob/issue_169/src/popup/popup.js#L141).