### PR TITLE
fix: Tagging is working again

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -183,7 +183,7 @@ async function load() {
   tagList.ignoreFocus = true;
   tagList.initItems(tags, null);
   tagList.addEventListener("item-selected", async (event) => {
-    await browser.runtime.sendMessage({ action: "processSelectedMessages", tag: event.detail.key, operation: "tag" });
+    await browser.runtime.sendMessage({ action: "processSelectedMessages", tag: event.detail.folder.key, operation: "tag" });
     window.close();
   });
 

--- a/src/popup/tagList.js
+++ b/src/popup/tagList.js
@@ -17,8 +17,7 @@ class TBTagList extends BaseItemList {
     let item = this.shadowRoot.ownerDocument.importNode(template.content, true);
     item.querySelector(".icon").innerHTML = BaseItemList.tagIcon(tag.color);
     item.querySelector(".text").textContent = tag.tag;
-    item.querySelector(".item").itemNode = tag;
-
+    item.querySelector(".item").itemNode = { item: tag };
     body.appendChild(item);
     return body.lastElementChild;
   }


### PR DESCRIPTION
Tagging is currently giving this error:

```
Uncaught (in promise) Error: Type error for parameter newProperties (Error processing tags.0: Expected string instead of undefined) for messages.update.
    applyTags moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/background.js:117
    applyTags moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/background.js:102
    spinWith moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/background.js:31
    <anonymous> moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/background.js:181
    load moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/popup/popup.js:186
    dispatchSelect moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/popup/baseItemList.js:378
    itemListClick moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/popup/baseItemList.js:368
    connectedCallback moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/popup/baseItemList.js:247
    <anonymous> moz-extension://e7252b71-5fcf-458f-af21-905f604adfad/popup/tagList.js:27
background.js:117:31
```

this PR fixes the issue.