### PR TITLE
feat: Improved destination path in the notification message

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,8 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Portions Copyright (C) Philipp Kewisch */
 
-import { showNotification } from "../common/util.js";
-import { DEFAULT_PREFERENCES } from "./common/util.js";
+import { DEFAULT_PREFERENCES, showNotification, prettyDestination } from "./common/util.js";
 
 const DEFAULT_ACTION_URL = "/popup/popup.html?action=move&allowed=move,copy,goto,tag";
 
@@ -100,7 +99,7 @@ async function processSelectedMessages(folder, operation = "move", goToFolder = 
   }
 
   if (operation != "goto" && notificationActive) {
-    showNotification(operation, numMessages, folderId);
+    showNotification(operation, numMessages, await prettyDestination(folderId));
   }
 }
 async function applyTags(tag, name) {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -62,3 +62,24 @@ export async function showNotification(operation, numMessages, destination, dism
     }, dismissTime);
   }
 }
+
+export async function prettyDestination(folderId, doReverse = false) {
+  // Split the folderId into accountId and path
+  const [accountId, path] = folderId.split("://");
+
+  const folders = path.split("/");
+  const account = await browser.accounts.get(accountId);
+  const accountName = account ? account.name : accountId;
+
+  let fullPath = [];
+  let divider = "";
+  if (doReverse) {
+    fullPath = [...folders.reverse(), accountName];
+    divider = "\u200B←";
+  } else {
+    fullPath = [accountName, ...folders];
+    divider = "→\u200B";
+  }
+
+  return fullPath.join(divider);
+}


### PR DESCRIPTION
I added the `prettyDestination(folderId, doReverse = false)` method.
I do no like the reverse order in the notification message. I added a parameter in the call to test it.
Also the `\` instead of the `→` is more compact.
What do you think?